### PR TITLE
Fix obsolete UIApplicationOpenURLOptionsKey

### DIFF
--- a/ios/Classes/SwiftFlutterAppAuthWrapperPlugin.swift
+++ b/ios/Classes/SwiftFlutterAppAuthWrapperPlugin.swift
@@ -100,7 +100,7 @@ public class SwiftFlutterAppAuthWrapperPlugin: NSObject, FlutterPlugin {
 		eventSink?(flutterError)
 	}
 	
-	public func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
+	public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
 		if (authFlow?.resumeExternalUserAgentFlow(with: url) ?? false) {
 			authFlow = nil
 			return true


### PR DESCRIPTION
Replace obsolete UIApplicationOpenURLOptionsKey with UIApplication.OpenURLOptionsKey.

The key is obsolete since Swift 4.2 and Xcode 11.3 throws an error when building the project.